### PR TITLE
otaserver: add new features

### DIFF
--- a/otaserver/coap.py
+++ b/otaserver/coap.py
@@ -6,12 +6,18 @@ import logging
 import aiocoap.resource as resource
 
 from aiocoap import Context, Message, CONTENT
+from functools import reduce
 
 logger = logging.getLogger("otaserver")
+COAP_PORT = 5678
 
-
-COAP_PORT = 5683
-
+class FirmwareUpdate(object):
+    """Firmware updates as files."""
+    def __init__(self, fw_name):
+        self.slot = os.path.splitext(fw_name.split("-")[-3])
+        self.appid = os.path.splitext(fw_name.split("-")[-2])
+        self.version = os.path.splitext(fw_name.split("-")[-1])
+        self.name = fw_name
 
 class FirmwareBinaryResource(resource.Resource):
     """CoAP resource returning the latest firmware."""
@@ -39,9 +45,10 @@ class FirmwareBinaryResource(resource.Resource):
 class FirmwareVersionResource(resource.Resource):
     """CoAP resource returning the firmware latest version."""
 
-    def __init__(self, controller):
+    def __init__(self, controller, appid):
         super(FirmwareVersionResource, self).__init__()
         self._controller = controller
+        self.appid = appid
 
     @asyncio.coroutine
     def render_get(self, request):
@@ -51,10 +58,36 @@ class FirmwareVersionResource(resource.Resource):
             remote = request.remote.sockaddr[0]
 
         logger.debug("CoAP GET received from {}".format(remote))
+        message = self._controller.get_latest_version(self.appid).encode('ascii')
+        logger.debug("Sending message: {}".format(message))
 
         return Message(
             code=CONTENT,
-            payload=self._controller.get_latest_version().encode('ascii'))
+            payload=message)
+
+class FirmwareNameResource(resource.Resource):
+    """CoAP resource returning the firmware name of latest version."""
+
+    def __init__(self, controller, appid, slot):
+        super(FirmwareNameResource, self).__init__()
+        self._controller = controller
+        self.appid = appid
+        self.slot = slot
+
+    @asyncio.coroutine
+    def render_get(self, request):
+        try:
+            remote = request.remote[0]
+        except TypeError:
+            remote = request.remote.sockaddr[0]
+
+        logger.debug("CoAP GET received from {}".format(remote))
+        message = self._controller.get_latest_fw_name(self.appid, self.slot).encode('ascii')
+        logger.debug("Sending message: {}".format(message))
+
+        return Message(
+            code=CONTENT,
+            payload=message)
 
 
 class CoapController():
@@ -64,24 +97,48 @@ class CoapController():
         self.port = port
         self.fw_path = fw_path
         root_coap = resource.Site()
-        root_coap.add_resource(('version', ), FirmwareVersionResource(self))
-        root_coap.add_resource(('firmware', ), FirmwareBinaryResource(self))
+        self.appids = {}
+        firmwares = os.listdir(self.fw_path)
+        for fw in firmwares:
+            firmware = FirmwareUpdate(fw)
+            appid = fw.split("-")[-2]
+            if appid in self.appids:
+                self.appids[appid].append(fw)
+                continue
+            self.appids[appid] = [fw]
+            print (appid)
+            root_coap.add_resource((appid, 'version', ), FirmwareVersionResource(self, appid))
+            root_coap.add_resource((appid, 'slot1', 'name', ), FirmwareNameResource(self, appid, 1))
+            root_coap.add_resource((appid, 'slot2', 'name', ), FirmwareNameResource(self, appid, 2))
+        
         asyncio.async(Context.create_server_context(root_coap,
                                                     bind=('::', self.port)))
 
-    def get_latest_version(self):
+    def get_latest_version(self, appid):
         """Get the latest firmware version."""
         firmwares = os.listdir(self.fw_path)
         if firmwares == []:
             return ''
         else:
-            return '.'.join(max(os.path.splitext(
-                fw)[0].split("-")[-1].split(".") for fw in firmwares))
+            fw_appids = list(filter(lambda x: x.split("-")[-2] == appid, firmwares))
+            return max([fw.split("-")[-1] for fw in fw_appids])
+
+    def get_latest_fw_name(self, appid, slot):
+        """Get the latest firmware name."""
+        firmwares = os.listdir(self.fw_path)
+        if firmwares == []:
+            return ''
+        else:
+            version = self.get_latest_version(appid)
+            fw_appids = list(filter(lambda x: x.split("-")[-2] == appid and x.split("-")[-1] == version, firmwares))
+            print (fw_appids)
+            fw_name = list(filter(lambda x: x.split("-")[-3] == 'slot' + str(slot), fw_appids))
+            print (fw_name)
+            return fw_name[0]
 
     def get_latest_firmware(self):
         """Get the latest firmware content."""
-        firmwares = os.listdir(self.fw_path)
         latest_version = self.get_latest_version()
-        firmware = [fw for fw in firmwares
+        firmware = [fw for fw in self.firmwares
                     if os.path.splitext(fw)[0].endswith(latest_version)][0]
         return open(os.path.join(self.fw_path, firmware), 'rb').read()


### PR DESCRIPTION
This PR adds new features to the server, needed for the RIOT ota_update module.

It parses now all the firmwares in the "static/uploads" given directory and checks for the firmware appids to generate a "version" and "name" resource for such appid.

When requested for the version of a given appid, the server returns the newest one following the naming schema in the file names. When requested for a name of a given appid, it returns the full name of the newest version for a given appid and slot.