### PR TITLE
Adding support for (tiny)DTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ First clone this repository:
 Then install OTA server:
 ```
     $ cd ota-server
-    $ sudo pip install .
+    $ sudo pip install . -r requirements.txt
 ```
 
 Finally install the Node modules required (you need to install
@@ -44,6 +44,9 @@ Notes:
 * Use `--debug` option if you want more output from the application.
 * Use `--coap-port` option to use another port for the CoAP server (5683 is the
   default).
+* Use `--dtls` option for enabling CoAP Secure.
+* Use `--coaps-port` option to use another port for the CoAP Secure server (
+    5684 is the default).  This requires `--dtls`).
 
 #### About the available firmwares:
 

--- a/otaserver/app.py
+++ b/otaserver/app.py
@@ -9,6 +9,7 @@ from tornado.options import define, options
 
 from .server import OTAServerApplication
 from .coap import COAP_PORT
+from .coap import COAPS_PORT
 
 logging.basicConfig(level=logging.DEBUG,
                     format='%(asctime)s - %(name)14s - '
@@ -29,6 +30,8 @@ def parse_command_line():
            help="Path where uploaded files are stored.")
     define("port", default=8080, help="Web application HTTP port.")
     define("coap_port", default=COAP_PORT, help="CoAP server port.")
+    define("dtls", default=False, help="Enable CoAP Secure")
+    define("coaps_port", default=COAPS_PORT, help="CoAPS server port")
     define("debug", default=False, help="Enable debug mode.")
     options.parse_command_line()
 

--- a/otaserver/coap.py
+++ b/otaserver/coap.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("otaserver")
 
 
 COAP_PORT = 5683
-
+COAPS_PORT = 5684
 
 class FirmwareBinaryResource(resource.Resource):
     """CoAP resource returning the latest firmware."""
@@ -91,14 +91,15 @@ class FirmwareNameResource(resource.Resource):
 class CoapController():
     """CoAP controller with CoAP server inside."""
 
-    def __init__(self, fw_path, port=COAP_PORT):
+    def __init__(self, fw_path, port=COAP_PORT, dtls_enabled=False):
         self.port = port
         self.fw_path = fw_path
         self.root_coap = resource.Site()
         for filename in os.listdir(fw_path):
             self.add_resources(filename)
         asyncio.async(Context.create_server_context(self.root_coap,
-                                                    bind=('::', self.port)))
+                                                    bind=('::', self.port),
+                                                    secure=dtls_enabled))
 
     def add_resources(self, filename):
         """Add new resources for the given application id."""

--- a/otaserver/server.py
+++ b/otaserver/server.py
@@ -99,9 +99,16 @@ class OTAServerApplication(web.Application):
                         static_path=options.static_path,
                         template_path=options.static_path,
                         )
+
+        if options.dtls:
+            _server_port=options.coaps_port
+        else:
+            _server_port=options.coap_port
+
         self.coap_server = CoapController(os.path.join(options.static_path,
                                                        "uploads"),
-                                          port=options.coap_port)
+                                          port=_server_port,
+                                          dtls_enabled=options.dtls)
 
         super().__init__(handlers, **settings)
         logger.info('Application started, listening on port {}'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+
+# NOTE: The official aiocoap repository does not support DTLS for
+#       the server side.
+-e git+https://github.com/rfuentess/aiocoap.git@tinydtls_server_v1#egg=aiocoap


### PR DESCRIPTION
This PR gives support for tinyDTLS (only PSK) by means of an updated to the aiocoap module. The user can enable this support with a new argument (`--dtls`).

The official repository implementation of aiocoap does not support tinyDTLS. Although there was an [effort on that topic](https://github.com/chrysn/aiocoap/issues/67#issuecomment-297917694). This forced me to use a [temporary fork](https://github.com/rfuentess/aiocoap/tree/tinydtls_server_v1) for supporting a server with DTLS, which is the reason of the use of r`equirements.txt` file. I hope that this specific commit can be suppressed in a future. 